### PR TITLE
Convert stack name into required field

### DIFF
--- a/cue.mod/usr/github.com/kick-my-sam/serverless/application.cue
+++ b/cue.mod/usr/github.com/kick-my-sam/serverless/application.cue
@@ -54,7 +54,7 @@ import (
 	global: *null | #Global
 
 	// S3 bucket uri to store application template
-	bucket: dagger.#Input & {*"s3://dagger-serverless-bucket" | =~"^s3:\/\/(.*)"}
+	bucket: dagger.#Input & {=~"^s3:\/\/(.*)"}
 
 	#manifest: {
 		AWSTemplateFormatVersion: "2010-09-09"

--- a/cue.mod/usr/github.com/kick-my-sam/serverless/code.cue
+++ b/cue.mod/usr/github.com/kick-my-sam/serverless/code.cue
@@ -18,6 +18,9 @@ import (
 	// Source code name
 	name: dagger.#Input & {=~"^[a-zA-Z-]+$"}
 
+	// Stack name to upload code
+	stackName: dagger.#Input & {=~"^[a-zA-Z-]+$"}
+
 	// Source code of lambda
 	source: dagger.#Input & {dagger.#Artifact | string}
 
@@ -25,7 +28,7 @@ import (
 	type: dagger.#Input & {*"Zip" | "Image"}
 
 	// Dagger serverless infrastructure deployment
-	infra: #Stack & {"config": config}
+	infra: #Stack & {"config": config, name: stackName}
 
 	// Function's handler
 	handler: dagger.#Input & {*null | =~"^[\\S]+$"}

--- a/cue.mod/usr/github.com/kick-my-sam/serverless/stack.cue
+++ b/cue.mod/usr/github.com/kick-my-sam/serverless/stack.cue
@@ -14,13 +14,13 @@ import (
 	config: aws.#Config
 
 	// Stack name
-	name: *"dagger-serverless" | =~"^[a-zA-Z0-9-_]+$"
+	name: dagger.#Input & {=~"^[a-zA-Z-]+$"}
 
 	// S3 bucket name
-	bucketName: *"dagger-serverless-bucket" | =~"^[a-zA-Z0-9-_]+$"
+	bucketName: *"\(name)-bucket" | =~"^[a-zA-Z-]+$"
 
 	// ECR repository name
-	registryName: *"dagger-serverless-registry" | =~"^[a-zA-Z0-9-_]+$"
+	registryName: *"\(name)-registry" | =~"^[a-zA-Z-]+$"
 
 	#template: json.Marshal({
 		AWSTemplateFormatVersion: "2010-09-09"

--- a/examples/application/application.cue
+++ b/examples/application/application.cue
@@ -14,18 +14,22 @@ TestConfig: aws.#Config & {
 
 TestCodeDirectory: dagger.#Input & {dagger.#Artifact}
 
+TestStackName: dagger.#Input & {*"dagger-serverless-application-test" | string}
+
 TestCode: serverless.#Code & {
-	name:    "go-cool-func"
-	config:  TestConfig
-	source:  TestCodeDirectory
-	handler: "lambda-tata"
+	name:      "go-cool-func"
+	stackName: TestStackName
+	config:    TestConfig
+	source:    TestCodeDirectory
+	handler:   "lambda-tata"
 }
 
 TestCode2: serverless.#Code & {
-	name:    "go-cool-func-two"
-	config:  TestConfig
-	source:  TestCodeDirectory
-	handler: "lambda-tata"
+	name:      "go-cool-func-two"
+	stackName: TestStackName
+	config:    TestConfig
+	source:    TestCodeDirectory
+	handler:   "lambda-tata"
 }
 
 TestFunctionZip: serverless.#Function & {
@@ -64,6 +68,7 @@ TestCors: serverless.#Cors & {
 TestApplication: serverless.#Application & {
 	config:      TestConfig
 	description: "My cool application"
+	bucket:      "s3://\(TestStackName)-bucket"
 	functions: {
 		myCoolFunc:  TestFunctionZip
 		myCoolFunc2: TestFunctionZip2

--- a/examples/code/code.cue
+++ b/examples/code/code.cue
@@ -14,18 +14,20 @@ TestConfig: aws.#Config & {
 TestCodeDirectory: dagger.#Input & {dagger.#Artifact}
 
 TestCodeZip: serverless.#Code & {
-	config:  TestConfig
-	name:    "goCoolFunc"
-	source:  TestCodeDirectory
-	handler: "index.handler"
+	config:    TestConfig
+	name:      "goCoolFunc"
+	stackName: "dagger-zip-code-test"
+	source:    TestCodeDirectory
+	handler:   "index.handler"
 }
 
 TestImageDirectory: dagger.#Input & {dagger.#Artifact}
 
 TestCodeImage: serverless.#Code & {
-	config:  TestConfig
-	name:    "goCoolImage"
-	source:  TestImageDirectory
-	type:    "Image"
-	handler: "index.handler"
+	config:    TestConfig
+	name:      "goCoolImage"
+	stackName: "dagger-image-code-test"
+	source:    TestImageDirectory
+	type:      "Image"
+	handler:   "index.handler"
 }

--- a/examples/function/function.cue
+++ b/examples/function/function.cue
@@ -16,18 +16,22 @@ TestConfig: aws.#Config & {
 
 TestCodeDirectory: dagger.#Input & {dagger.#Artifact}
 
+TestStackName: dagger.#Input & {*"dagger-serverless-function-test" | string}
+
 TestCode: serverless.#Code & {
-	name:    "go-cool-func"
-	config:  TestConfig
-	source:  TestCodeDirectory
-	handler: "index.handler"
+	name:      "go-cool-func"
+	stackName: TestStackName
+	config:    TestConfig
+	source:    TestCodeDirectory
+	handler:   "index.handler"
 }
 
 TestCode2: serverless.#Code & {
-	name:    "go-cool-func-two"
-	config:  TestConfig
-	source:  TestCodeDirectory
-	handler: "index.handler"
+	name:      "go-cool-func-two"
+	stackName: TestStackName
+	config:    TestConfig
+	source:    TestCodeDirectory
+	handler:   "index.handler"
 }
 
 api: events.#Api & {

--- a/examples/stack/stack.cue
+++ b/examples/stack/stack.cue
@@ -11,4 +11,5 @@ TestConfig: aws.#Config & {
 
 TestStack: serverless.#Stack & {
 	config: TestConfig
+	name: "dagger-test-stack-serverless"
 }

--- a/examples/tata-app/tata-app.cue
+++ b/examples/tata-app/tata-app.cue
@@ -1,11 +1,8 @@
 package tata
 
 import (
-	//"encoding/json"
 
 	"alpha.dagger.io/dagger"
-	//"alpha.dagger.io/dagger/op"
-	//"alpha.dagger.io/alpine"
 	"alpha.dagger.io/aws"
 
 	"github.com/kick-my-sam/serverless"
@@ -18,11 +15,14 @@ TestConfig: aws.#Config & {
 
 TestCodeDirectory: dagger.#Input & {dagger.#Artifact}
 
+TestStackName: dagger.#Input & {*"dagger-serverless-function-test" | string}
+
 TestCodeZip: serverless.#Code & {
-	config:  TestConfig
-	name:    "myCode"
-	source:  TestCodeDirectory
-	handler: "lambda-tata"
+	config:    TestConfig
+	name:      "myCode"
+	stackName: TestStackName
+	source:    TestCodeDirectory
+	handler:   "lambda-tata"
 }
 
 TestFunctionZip: serverless.#Function & {
@@ -36,8 +36,9 @@ TestFunctionZip: serverless.#Function & {
 }
 
 TestApplication: serverless.#Application & {
-	name: "TataApp"
+	name:        "TataApp"
 	config:      TestConfig
+	bucket:      TestCodeZip.infra.bucketUri
 	description: "My tata app"
 	functions: {
 		"Tata": TestFunctionZip


### PR DESCRIPTION
## Changes

There was an issue with the default value of the stack name.
We can't have two users with the same bucket name in the same region.

So I've put the stack name field as required to avoid that problem.