### PR TITLE
Convert methods and headers fields from #Cors to lists

### DIFF
--- a/cue.mod/usr/github.com/kick-my-sam/serverless/api.cue
+++ b/cue.mod/usr/github.com/kick-my-sam/serverless/api.cue
@@ -1,21 +1,26 @@
 package serverless
 
 import (
+	"strings"
+
 	"alpha.dagger.io/dagger"
 )
+
+// Available http methods
+#HttpMethod: "GET" | "HEAD" | "POST" | "PUT" |
+	"DELETE" | "CONNECT" | "OPTIONS" | "TRACE" | "PATCH"
 
 #Cors: {
 	// String of origin to allow
 	origin: dagger.#Input & {=~"^[\\S]+$"}
 
 	// String of headers to allow
-	// E.g "X-Forwarded-For"
-	headers: dagger.#Input & {*null | =~"^[\\S]+$"}
+	// E.g ["X-Forwarded-For", "content-type"]
+	headers: [...=~"^[\\S]+$"]
 
 	// String containing the HTTP methods to allow
-	// E.g "GET, POST"
-	// TODO Take an array of string instead of sentence
-	methods: dagger.#Input & {*null | string}
+	// E.g ["GET", "POST"]
+	methods: [...#HttpMethod]
 
 	// String containing the number of seconds to cache CORS Preflight reques
 	maxAge: dagger.#Input & {*null | number & >0}
@@ -25,11 +30,11 @@ import (
 
 	#manifest: {
 		AllowOrigin: "'\(origin)'"
-		if methods != null {
-			AllowMethods: "'\(methods)'"
+		if len(methods) > 0 {
+			AllowMethods: "'\(strings.Join(methods, ", "))'"
 		}
-		if headers != null {
-			AllowHeaders: "'\(headers)'"
+		if len(headers) > 0 {
+			AllowHeaders: "'\(strings.Join(headers, ", "))'"
 		}
 		if maxAge != null {
 			MaxAge: "'\(maxAge)'"

--- a/examples/api/api.cue
+++ b/examples/api/api.cue
@@ -1,13 +1,17 @@
 package example
 
 import (
+	"encoding/json"
+
+	"alpha.dagger.io/dagger"
+
 	"github.com/kick-my-sam/serverless"
 )
 
 TestCors: serverless.#Cors & {
-	origin:  "example.com"
-	methods: "GET"
-	maxAge:  500
+	origin: "example.com"
+	methods: ["GET", "POST"]
+	maxAge: 500
 }
 
 TestApi: serverless.#Api & {
@@ -19,7 +23,8 @@ TestApi: serverless.#Api & {
 // From official aws reference
 // https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-api.html#sam-api-models
 TestApiWithModel: serverless.#Api & {
-	name: "inlineModelApi"
+	name:  "inlineModelApi"
+	stage: "Model"
 	models: {
 		User: serverless.#Model & {
 			type: "object"
@@ -43,3 +48,6 @@ TestApiWithModel: serverless.#Api & {
 		}
 }
 }
+
+output1: dagger.#Output & {json.Marshal(TestApi.#manifest)}
+output2: dagger.#Output & {json.Marshal(TestApiWithModel.#manifest)}


### PR DESCRIPTION
In order to improve UX, I've transform methods and headers into lists
Before, to precise many methods, it was required to write "GET, POST"
That's not really friendly and IMO it can lead to incomprehension.
Now, you can provide methods with an array like this : ["GET", "POST"].

I've also add a #HttpMethods definition to improve data validation

Signed-off-by: Tom Chauveau <tom.chauveau@epitech.eu>