### PR TITLE
Fix s3 bucket name

### DIFF
--- a/cue.mod/usr/github.com/kick-my-sam/aws/sam/sam.cue
+++ b/cue.mod/usr/github.com/kick-my-sam/aws/sam/sam.cue
@@ -19,7 +19,7 @@ import (
 	template: dagger.#Input & {string}
 
 	// S3 bucket uri to store template 
-	bucket: dagger.#Input & {=~"^s3:\/\/(.*)"}
+	bucket: dagger.#Input & {=~"^[a-zA-Z-]+$"}
 
 	outputs: [string]: string & dagger.#Output
 	outputs: #up: [

--- a/cue.mod/usr/github.com/kick-my-sam/serverless/application.cue
+++ b/cue.mod/usr/github.com/kick-my-sam/serverless/application.cue
@@ -54,7 +54,7 @@ import (
 	global: *null | #Global
 
 	// S3 bucket uri to store application template
-	bucket: dagger.#Input & {=~"^s3:\/\/(.*)"}
+	bucket: dagger.#Input & {=~"^[a-zA-Z-]+$"}
 
 	#manifest: {
 		AWSTemplateFormatVersion: "2010-09-09"

--- a/examples/application/application.cue
+++ b/examples/application/application.cue
@@ -68,7 +68,7 @@ TestCors: serverless.#Cors & {
 TestApplication: serverless.#Application & {
 	config:      TestConfig
 	description: "My cool application"
-	bucket:      "s3://\(TestStackName)-bucket"
+	bucket:      TestCode.infra.bucketName
 	functions: {
 		myCoolFunc:  TestFunctionZip
 		myCoolFunc2: TestFunctionZip2

--- a/examples/tata-app/tata-app.cue
+++ b/examples/tata-app/tata-app.cue
@@ -38,7 +38,7 @@ TestFunctionZip: serverless.#Function & {
 TestApplication: serverless.#Application & {
 	name:        "TataApp"
 	config:      TestConfig
-	bucket:      TestCodeZip.infra.bucketUri
+	bucket:      TestCodeZip.infra.bucketName
 	description: "My tata app"
 	functions: {
 		"Tata": TestFunctionZip


### PR DESCRIPTION
## Changes

The official `aws cloudformation package` command doesn't need the `s3://` prefix on `--s3-bucket` option.
This PR correct that bug with a new regexp validation