### PR TITLE
Outputs now take in account events' kind

### DIFF
--- a/cue.mod/usr/github.com/kick-my-sam/serverless/application.cue
+++ b/cue.mod/usr/github.com/kick-my-sam/serverless/application.cue
@@ -7,6 +7,7 @@ import (
 	"alpha.dagger.io/aws"
 
 	"github.com/kick-my-sam/aws/sam"
+	"github.com/kick-my-sam/serverless/events"
 )
 
 #Global: {
@@ -81,13 +82,24 @@ import (
 		}
 
 		Outputs: {
-			URL: {
-				Description: "API Gateway endpoint URL"
-				if api != null {
+			if api != null {
+				URL: {
+					Description: "API Gateway endpoint URL"
 					Value: "Fn::Sub": "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/\(api.stage)/"
 				}
-				if api == null {
-					Value: "Fn::Sub": "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
+			}
+			if api == null {
+				// Check if an API Gateway is generated
+				let _isApi = #_IsEventInFunctions & {
+					type:        events.#Api
+					"functions": functions
+				}
+
+				if _isApi.res == true {
+					URL: {
+						Description: "API Gateway endpoint URL"
+						Value: "Fn::Sub": "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
+					}
 				}
 			}
 			for name, f in functions {

--- a/cue.mod/usr/github.com/kick-my-sam/serverless/function.cue
+++ b/cue.mod/usr/github.com/kick-my-sam/serverless/function.cue
@@ -1,12 +1,33 @@
 package serverless
 
 import (
+	"struct"
+
 	"alpha.dagger.io/dagger"
 	"github.com/kick-my-sam/serverless/events"
 )
 
 // Event list
 #Event: events.#Api | events.#SQS
+
+// Check if a provided event exists
+// in a map of functions
+// If exist : res = true else false
+#_IsEventInFunctions: {
+	type: #Event
+
+	functions: [string]: #Function
+
+	res: *false | bool
+
+	for _, function in functions {
+		for _, e in function.events {
+			if (e & type) != _|_ {
+				res: true
+			}
+		}
+	}
+}
 
 // Build AWS::ServerlessFunction
 #Function: {


### PR DESCRIPTION
Previously, there was always an output `URL` when deploy SAM App.
But that was a wrong behavior because the url is only valid if we got `API` events.

> :bulb: AWS SAM generated an API gateway if there are.

Now, we check that there is an event API because output an URL to avoid invalid SAM configuration.